### PR TITLE
Fix failure when target period is DJF

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 kjhall-iri
+Copyright (c) 2022 Kyle Hall and IRI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -49,5 +49,5 @@ pytest -v .
 ```
 
 
-for support: awr@iri.columbia.edu
+for support: pycpt-help@iri.columbia.edu
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ git clone https://github.com/iri-pycpt/cpt-io.git
 cd cpt-io
 pip install -e .
 python
-import src/cptio as cptio
+import cptio
 ```
 Changes you make to the library will take effect when you restart python, no need to build the package first.
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -4,7 +4,6 @@ package:
 
 source:
   path: ..
-  # url: https://github.com/kjhall-iri/pycpt/archive/refs/tags/v0.0.1.tar.gz
 
 build:
   number: 0
@@ -28,8 +27,8 @@ test:
     
 
 about:
-  home: https://github.com/kjhall-iri/
+  home: https://github.com/iri-pycpt/
   license: MIT
   summary: 'toolkit bridging the gap between CPT and Xarray' 
   description: 'CPT Xarray Tools & IRI DL Downloads'
-  dev_url: https://github.com/kjhall-iri/
+  dev_url: https://github.com/iri-pycpt/

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: cptio
-  version: "1.0.1"
+  version: "1.0.2"
 
 source:
   path: ..

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 A python library for reading and writing CPTv10-formatted tab-separated values (tsv) files via Xarray
 
 
-Maintainer: Kyle Hall (kjhall@iri.columbia.edu) 
+Maintainer: IRI (pycpt-help@iri.columbia.edu)
 
 ### Installation
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     name = "cptio",
     version = "1.0.1",
     author = "Kyle Hall",
-    author_email = "kjhall@iri.columbia.edu",
+    author_email = "pycpt-help@iri.columbia.edu",
     description = ("Tools bridging Xarray and CPT"),
     license = "MIT",
     keywords = ["climate", 'predictability', 'prediction', 'precipitation', 'temperature', 'data', 'IRI'],

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = readme_path.read_text(encoding='utf-8')
 
 setup(
     name = "cptio",
-    version = "1.0.1",
+    version = "1.0.2",
     author = "Kyle Hall",
     author_email = "pycpt-help@iri.columbia.edu",
     description = ("Tools bridging Xarray and CPT"),

--- a/src/cptio/__init__.py
+++ b/src/cptio/__init__.py
@@ -18,5 +18,5 @@ from .utilities import (
 
 
 __version__ = "1.0.1"
-__author__ = "Kyle Hall (kjhall@iri.columbia.edu)"
+__author__ = "Kyle Hall (pycpt-help@iri.columbia.edu)"
 __license__ = "MIT"

--- a/src/cptio/__init__.py
+++ b/src/cptio/__init__.py
@@ -1,8 +1,22 @@
-from .fileio import open_cptdataset, to_cptv10, guess_cptv10_coords, convert_np64_datetime
-from .utilities import rmrf, rmstar, ls_files_recursive, threeletters, recursive_getattr, seasonal_target_length, target_from_leads, leads_from_target, is_valid_cptv10
+from .fileio import (
+    open_cptdataset,
+    to_cptv10,
+    guess_cptv10_coords,
+    convert_np64_datetime,
+)
+from .utilities import (
+    rmrf,
+    rmstar,
+    ls_files_recursive,
+    threeletters,
+    recursive_getattr,
+    seasonal_target_length,
+    target_from_leads,
+    leads_from_target,
+    is_valid_cptv10,
+)
 
 
 __version__ = "1.0.1"
-__author__  = "Kyle Hall (kjhall@iri.columbia.edu)"
+__author__ = "Kyle Hall (kjhall@iri.columbia.edu)"
 __license__ = "MIT"
-

--- a/src/cptio/__init__.py
+++ b/src/cptio/__init__.py
@@ -17,6 +17,6 @@ from .utilities import (
 )
 
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 __author__ = "Kyle Hall (pycpt-help@iri.columbia.edu)"
 __license__ = "MIT"

--- a/src/cptio/fileio/__init__.py
+++ b/src/cptio/fileio/__init__.py
@@ -1,1 +1,1 @@
-from .cpt import * 
+from .cpt import *

--- a/src/cptio/fileio/cpt.py
+++ b/src/cptio/fileio/cpt.py
@@ -353,14 +353,21 @@ def datetime_timestamp_end(date):
         ymd, hms = date.split("T")
     else:
         ymd = date
-    last_days = [None, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
     fields = [int(i) for i in ymd.split("-")]
-    while len(fields) < 3:
-        if len(fields) == 1:
-            fields.append(12)
+    y = fields[0]
+    m = fields[1]
+    if len(fields) == 3:
+        d = fields[2]
+    elif len(fields) == 2:
+        if m == 12:
+            d = 31
         else:
-            fields.append(last_days[fields[1]])
-    return dt.datetime(*fields)
+            # Find the first day of the following month, then back up
+            # one day.
+            d = (dt.datetime(y, m + 1, 1) - dt.timedelta(days=1)).day
+    else:
+        assert False, f"Can't parse date {ymd}"
+    return dt.datetime(y, m, d)
 
 
 def read_cpt_date(date_original):

--- a/src/cptio/fileio/cpt.py
+++ b/src/cptio/fileio/cpt.py
@@ -139,13 +139,16 @@ def open_cptdataset(filename):
                     pass
             data = array[:, 1:].astype(float)
 
-            # The first CPT header always has a 'field' field indicating the variable stored. It is assumed to be the same thereafter if not explicitly changed
+            # The first CPT header always has a 'field' field
+            # indicating the variable stored. It is assumed to be the
+            # same thereafter if not explicitly changed
             field = (
                 header[2]["field"] if "field" in header[2].keys() else attrs["field"]
             )
 
             if field not in data_vars.keys():
-                # now identify dimensions: 'T', 'Mode', 'C' - same deal , the same thereafter unless changed.
+                # now identify dimensions: 'T', 'Mode', 'C' - same
+                # deal , the same thereafter unless changed.
                 rowdim = header[2]["row"] if "row" in header[2].keys() else attrs["row"]
                 coldim = header[2]["col"] if "col" in header[2].keys() else attrs["col"]
                 somedims = [
@@ -193,12 +196,16 @@ def open_cptdataset(filename):
                 ndims = len(alldims)
                 if (
                     "C" in alldims and ndims == 4
-                ):  # to accomodate 4D data, we sort C to the first dimension, do all the C's separately, then shove them together in the end.
+                ):  # to accomodate 4D data, we sort C to the first
+                    # dimension, do all the C's separately, then shove
+                    # them together in the end.
                     alldims.pop(alldims.index("C"))
                     alldims.insert(0, "C")
                 if (
                     "M" in alldims and ndims == 4
-                ):  # to accomodate 4D data, we sort C to the first dimension, do all the C's separately, then shove them together in the end.
+                ):  # to accomodate 4D data, we sort C to the first
+                    # dimension, do all the C's separately, then shove
+                    # them together in the end.
                     alldims.pop(alldims.index("M"))
                     alldims.insert(0, "M")
                 data_vars[field] = {

--- a/src/cptio/fileio/cpt.py
+++ b/src/cptio/fileio/cpt.py
@@ -674,7 +674,18 @@ def format_date(t):
 def format_date_range(ti, tf):
     ti = convert_np64_datetime(ti)
     tf = convert_np64_datetime(tf)
-    return '{}-{}-{}/{}-{}-{}'.format(
-        ti.year, ti.month, ti.day,
-        tf.year, tf.month, tf.day
-    )
+    # If it looks like a season (sequence of full months), use monthly
+    # notation instead of daily. While it's usually ok to represent a
+    # season using daily notation, it's not ok if the season ends in
+    # February, because when using the daily notation, CPT rejects
+    # seasons whose length is different in leap years.
+    if is_season(ti, tf):
+        result = f"{ti.year}-{ti.month}/{tf.year}-{tf.month}"
+    else:
+        result = f"{ti.year}-{ti.month}-{ti.day}/{tf.year}-{tf.month}-{tf.day}"
+    return result
+
+
+def is_season(ti, tf):
+    '''True if ti is the first day of a month and tf is the last day of a month.'''
+    return ti.day == 1 and (tf + dt.timedelta(days=1)).day == 1

--- a/src/cptio/fileio/cpt.py
+++ b/src/cptio/fileio/cpt.py
@@ -1,73 +1,124 @@
-from pathlib import Path 
-import os , re
-import datetime as dt 
-import numpy as np 
-import xarray as xr 
+from pathlib import Path
+import os, re
+import datetime as dt
+import numpy as np
+import xarray as xr
 from io import StringIO
 
 
 def is_valid_cptv10(da, assertmissing=True, assert_units=True):
-    valid_dims = ['T', 'X', 'Y', 'Mode', 'index', 'C', 'M']
-    valid_coords = ['T', 'Ti', 'Tf', 'S', 'X', 'Y', 'Mode', 'index', 'C', 'M']
+    valid_dims = ["T", "X", "Y", "Mode", "index", "C", "M"]
+    valid_coords = ["T", "Ti", "Tf", "S", "X", "Y", "Mode", "index", "C", "M"]
     assert type(da) == xr.DataArray, "CPTv10 only deals with data arrays, not datasets"
-    assert len(list(da.dims)) >= 2 and len(list(da.dims)) <= 4, 'CPTv10 can only have between 2-4 dimensions'
+    assert (
+        len(list(da.dims)) >= 2 and len(list(da.dims)) <= 4
+    ), "CPTv10 can only have between 2-4 dimensions"
     for dim in da.dims:
-        assert dim in valid_dims, 'Invalid dim for a CPTv10: {}'.format(dim)
-    for coord in da.coords: 
-         assert coord in valid_coords, 'Invalid coord for a CPTv10: {}'.format(coord)
+        assert dim in valid_dims, "Invalid dim for a CPTv10: {}".format(dim)
+    for coord in da.coords:
+        assert coord in valid_coords, "Invalid coord for a CPTv10: {}".format(coord)
     for dim in da.dims:
-        assert dim in da.coords, 'Each dim on a CPTv10 must have corresponding coordinates'
-        assert len(da.coords[dim].values) == da.shape[list(da.dims).index(dim)], 'Each dim on a CPTv10 must have exactly one coordinate per index along that dimension'
-    if 'T' in da.dims: 
-        for dim in ['Ti', 'Tf', 'S']:
-            if dim in da.coords: 
-                assert len(da.coords[dim].values) == da.shape[list(da.dims).index('T')], 'If the CPTv10 has optional Time coordinates Ti, Tf, or S, they must be indexing the T dimension'
-    for dim in ['Ti', 'Tf', 'S']: 
-        if dim in da.dims: 
-            assert 'T' in da.dims, "if the optional time coordinates are present on the CPTv10, the required time coord must also be"
-    if 'Ti' in da.coords:
-        assert 'Tf' in da.coords, 'Cannot have one optional time coordinate and not the other. found Ti but not Tf. except for S'
-    if 'Tf' in da.coords:
-        assert 'Ti' in da.coords, 'Cannot have one optional time coordinate and not the other. found Tf but not Ti. except for S'
+        assert (
+            dim in da.coords
+        ), "Each dim on a CPTv10 must have corresponding coordinates"
+        assert (
+            len(da.coords[dim].values) == da.shape[list(da.dims).index(dim)]
+        ), "Each dim on a CPTv10 must have exactly one coordinate per index along that dimension"
+    if "T" in da.dims:
+        for dim in ["Ti", "Tf", "S"]:
+            if dim in da.coords:
+                assert (
+                    len(da.coords[dim].values) == da.shape[list(da.dims).index("T")]
+                ), "If the CPTv10 has optional Time coordinates Ti, Tf, or S, they must be indexing the T dimension"
+    for dim in ["Ti", "Tf", "S"]:
+        if dim in da.dims:
+            assert (
+                "T" in da.dims
+            ), "if the optional time coordinates are present on the CPTv10, the required time coord must also be"
+    if "Ti" in da.coords:
+        assert (
+            "Tf" in da.coords
+        ), "Cannot have one optional time coordinate and not the other. found Ti but not Tf. except for S"
+    if "Tf" in da.coords:
+        assert (
+            "Ti" in da.coords
+        ), "Cannot have one optional time coordinate and not the other. found Tf but not Ti. except for S"
     if assertmissing:
-        assert 'missing' in da.attrs.keys(), "CPTv10 is required to have a 'missing' attribute indicating the 'missing_value' value which replaces NaNs in CPT"
-        assert not np.isnan(float(da.attrs['missing'])), "CPTv10 Missing Value cannot be NaN"
-    
-    if assert_units:
-        assert 'units' in da.attrs.keys(), 'CPTv10 is required to have a "units" attribute'  
+        assert (
+            "missing" in da.attrs.keys()
+        ), "CPTv10 is required to have a 'missing' attribute indicating the 'missing_value' value which replaces NaNs in CPT"
+        assert not np.isnan(
+            float(da.attrs["missing"])
+        ), "CPTv10 Missing Value cannot be NaN"
 
+    if assert_units:
+        assert (
+            "units" in da.attrs.keys()
+        ), 'CPTv10 is required to have a "units" attribute'
 
 
 def cpt_headers(header):
     m = re.compile("(?P<tag>cpt:.*?|cf:.*?)=(?P<value>.*?,|.*$)")
     matches = m.findall(header)
-    return len(matches), { i.split(':')[1]: j.replace(',', '') for i,j in matches  }
+    return len(matches), {i.split(":")[1]: j.replace(",", "") for i, j in matches}
+
 
 def open_cptdataset(filename):
-    assert Path(filename).absolute().is_file(), 'Cannot find {}'.format(Path(filename).absolute())
-    with open(str(Path(filename).absolute()), 'r') as f: 
-        content1 = f.read() 
-    content = [line.strip() for line in content1.split("\n") if 'xmlns' not in line] 
-    xmlnns_lines = [line.strip() for line in content1.split("\n") if 'xmlns' in line ]
-    assert 'xmlns:cpt=http://iri.columbia.edu/CPT/v10/' in ' '.join(xmlnns_lines), 'CPT XML Namespace: {} Not detected'.format('xmlns:cpt=http://iri.columbia.edu/CPT/v10/')
-    headers = [(linenum, *cpt_headers(line)) if ',' in line or ('=' in line and 'ncats' not in line and 'nfields' not in line) else ( linenum, line ) for linenum, line in enumerate(content) if 'cpt:' in line ]
+    assert Path(filename).absolute().is_file(), "Cannot find {}".format(
+        Path(filename).absolute()
+    )
+    with open(str(Path(filename).absolute()), "r") as f:
+        content1 = f.read()
+    content = [line.strip() for line in content1.split("\n") if "xmlns" not in line]
+    xmlnns_lines = [line.strip() for line in content1.split("\n") if "xmlns" in line]
+    assert "xmlns:cpt=http://iri.columbia.edu/CPT/v10/" in " ".join(
+        xmlnns_lines
+    ), "CPT XML Namespace: {} Not detected".format(
+        "xmlns:cpt=http://iri.columbia.edu/CPT/v10/"
+    )
+    headers = [
+        (linenum, *cpt_headers(line))
+        if "," in line
+        or ("=" in line and "ncats" not in line and "nfields" not in line)
+        else (linenum, line)
+        for linenum, line in enumerate(content)
+        if "cpt:" in line
+    ]
     attrs, data_vars = {}, {}
-    for i, header in enumerate(headers): 
-        if len( header) == 3:  # we are only looking at the CPT headers that preceed a data block
-            attrs_at_row = { k: header[2][k] for k in  header[2].keys() if k not in ['T', 'S'] }
+    for i, header in enumerate(headers):
+        if (
+            len(header) == 3
+        ):  # we are only looking at the CPT headers that preceed a data block
+            attrs_at_row = {
+                k: header[2][k] for k in header[2].keys() if k not in ["T", "S"]
+            }
             attrs.update(attrs_at_row)
-            array = np.genfromtxt( StringIO('\n'.join(content[header[0]+2:header[0]+2+ int(attrs['nrow'])])), delimiter='\t', dtype=str)
-            columns = np.genfromtxt(StringIO(content[header[0]+1]), delimiter='\t', dtype=str)
+            array = np.genfromtxt(
+                StringIO(
+                    "\n".join(
+                        content[header[0] + 2 : header[0] + 2 + int(attrs["nrow"])]
+                    )
+                ),
+                delimiter="\t",
+                dtype=str,
+            )
+            columns = np.genfromtxt(
+                StringIO(content[header[0] + 1]), delimiter="\t", dtype=str
+            )
             try:
                 columns = columns.astype(float)
-            except: 
-                try: 
-                    columns = np.asarray([ read_cpt_date(ii) for ii in columns])
+            except:
+                try:
+                    columns = np.asarray([read_cpt_date(ii) for ii in columns])
                 except:
-                    pass 
-            columns = np.expand_dims(columns, 0) if len(columns.shape) < 1 else np.squeeze(columns )
+                    pass
+            columns = (
+                np.expand_dims(columns, 0)
+                if len(columns.shape) < 1
+                else np.squeeze(columns)
+            )
 
-            if len(array.shape) < 2: 
+            if len(array.shape) < 2:
                 array = array.reshape(1, -1)
             rows = np.squeeze(array[:, 0])
             rows = np.expand_dims(rows, 0) if len(rows.shape) < 1 else np.squeeze(rows)
@@ -75,306 +126,494 @@ def open_cptdataset(filename):
                 rows = rows.astype(float)
             except:
                 try:
-                    rows = np.asarray([ read_cpt_date(ii) for ii in rows])
+                    rows = np.asarray([read_cpt_date(ii) for ii in rows])
                 except:
                     pass
             data = array[:, 1:].astype(float)
 
-            # The first CPT header always has a 'field' field indicating the variable stored. It is assumed to be the same thereafter if not explicitly changed 
-            field = header[2]['field'] if 'field' in header[2].keys() else attrs['field']
+            # The first CPT header always has a 'field' field indicating the variable stored. It is assumed to be the same thereafter if not explicitly changed
+            field = (
+                header[2]["field"] if "field" in header[2].keys() else attrs["field"]
+            )
 
             if field not in data_vars.keys():
-                #now identify dimensions: 'T', 'Mode', 'C' - same deal , the same thereafter unless changed. 
-                rowdim= header[2]['row'] if 'row' in header[2].keys() else attrs['row']
-                coldim= header[2]['col'] if 'col' in header[2].keys() else attrs['col']
-                somedims = [  'T' if 'T' in header[2].keys() and 'T' not in [rowdim, coldim] else None,  'Mode' if 'Mode' in header[2].keys() and 'Mode' not in [rowdim, coldim] else None, 'C' if 'C' in header[2].keys() and 'C' not in [rowdim, coldim] else None, 'M' if 'M' in header[2].keys() and 'M' not in [rowdim, coldim] else None ]
-                somedims = [ jj for jj in somedims if jj is not None ] # keep only dims present 
-                alldims = [  rowdim, coldim ]
+                # now identify dimensions: 'T', 'Mode', 'C' - same deal , the same thereafter unless changed.
+                rowdim = header[2]["row"] if "row" in header[2].keys() else attrs["row"]
+                coldim = header[2]["col"] if "col" in header[2].keys() else attrs["col"]
+                somedims = [
+                    "T"
+                    if "T" in header[2].keys() and "T" not in [rowdim, coldim]
+                    else None,
+                    "Mode"
+                    if "Mode" in header[2].keys() and "Mode" not in [rowdim, coldim]
+                    else None,
+                    "C"
+                    if "C" in header[2].keys() and "C" not in [rowdim, coldim]
+                    else None,
+                    "M"
+                    if "M" in header[2].keys() and "M" not in [rowdim, coldim]
+                    else None,
+                ]
+                somedims = [
+                    jj for jj in somedims if jj is not None
+                ]  # keep only dims present
+                alldims = [rowdim, coldim]
                 somedims.extend(alldims)
                 alldims = somedims
                 coords = {}
                 for jj in alldims:
                     if jj not in [rowdim, coldim]:
-                        if jj == 'T':
+                        if jj == "T":
                             date_coord = read_cpt_date(header[2][jj])
-                            if len(date_coord) == 1: 
-                                coords[jj] = [ date_coord[0]  ]
+                            if len(date_coord) == 1:
+                                coords[jj] = [date_coord[0]]
                             else:
-                                coords['T'] = [date_coord[1]]
-                                coords['Ti'] = [date_coord[0]]
-                                coords['Tf'] = [date_coord[2]]
+                                coords["T"] = [date_coord[1]]
+                                coords["Ti"] = [date_coord[0]]
+                                coords["Tf"] = [date_coord[2]]
                         else:
-                            coords[jj] = [ header[2][jj] ] 
+                            coords[jj] = [header[2][jj]]
                 temp = {rowdim: rows, coldim: columns}
-                if 'T' in [rowdim, coldim]:
-                    date_coords =  temp['T']
-                    temp['T'] = [date_coords[ii][1] for ii in range(len(date_coords)) ]
-                    temp['Ti'] = [date_coords[ii][0] for ii in range(len(date_coords)) ]
-                    temp['Tf'] = [date_coords[ii][2] for ii in range(len(date_coords)) ]
+                if "T" in [rowdim, coldim]:
+                    date_coords = temp["T"]
+                    temp["T"] = [date_coords[ii][1] for ii in range(len(date_coords))]
+                    temp["Ti"] = [date_coords[ii][0] for ii in range(len(date_coords))]
+                    temp["Tf"] = [date_coords[ii][2] for ii in range(len(date_coords))]
                 coords.update(temp)
-                if 'S' in header[2].keys(): # S is always a length-1 situation
-                    coords.update({'S': [read_cpt_date(header[2]['S'])[0]]})
+                if "S" in header[2].keys():  # S is always a length-1 situation
+                    coords.update({"S": [read_cpt_date(header[2]["S"])[0]]})
                 ndims = len(alldims)
-                if 'C' in alldims and ndims==4:  # to accomodate 4D data, we sort C to the first dimension, do all the C's separately, then shove them together in the end.
-                    alldims.pop(alldims.index('C'))
-                    alldims.insert(0, 'C') 
-                if 'M' in alldims and ndims==4:  # to accomodate 4D data, we sort C to the first dimension, do all the C's separately, then shove them together in the end.
-                    alldims.pop(alldims.index('M'))
-                    alldims.insert(0, 'M') 
-                data_vars[field] = {'dims': alldims, 'coords':coords, 'data':  data if ndims == 2 else np.expand_dims(data, 0) if ndims == 3 else [np.expand_dims(data, 0)] if ndims == 4 else None, 'attrs': attrs}
-               # print('found {}-dimensional variable {}'.format(len(alldims), field))
-            else: 
-                # detect new coordinates in T, C, or Mode: 
-                for dim in data_vars[field]['coords'].keys():
+                if (
+                    "C" in alldims and ndims == 4
+                ):  # to accomodate 4D data, we sort C to the first dimension, do all the C's separately, then shove them together in the end.
+                    alldims.pop(alldims.index("C"))
+                    alldims.insert(0, "C")
+                if (
+                    "M" in alldims and ndims == 4
+                ):  # to accomodate 4D data, we sort C to the first dimension, do all the C's separately, then shove them together in the end.
+                    alldims.pop(alldims.index("M"))
+                    alldims.insert(0, "M")
+                data_vars[field] = {
+                    "dims": alldims,
+                    "coords": coords,
+                    "data": data
+                    if ndims == 2
+                    else np.expand_dims(data, 0)
+                    if ndims == 3
+                    else [np.expand_dims(data, 0)]
+                    if ndims == 4
+                    else None,
+                    "attrs": attrs,
+                }
+            # print('found {}-dimensional variable {}'.format(len(alldims), field))
+            else:
+                # detect new coordinates in T, C, or Mode:
+                for dim in data_vars[field]["coords"].keys():
                     if dim in header[2].keys():
-                        if dim == 'T':
-                            date_coord = read_cpt_date(header[2][dim]) 
-                            if len(date_coord) == 1: 
-                                if date_coord[0] not in data_vars[field]['coords'][dim]:
-                                    data_vars[field]['coords'][dim].append(date_coord[0])
+                        if dim == "T":
+                            date_coord = read_cpt_date(header[2][dim])
+                            if len(date_coord) == 1:
+                                if date_coord[0] not in data_vars[field]["coords"][dim]:
+                                    data_vars[field]["coords"][dim].append(
+                                        date_coord[0]
+                                    )
                             else:
-                                if date_coord[1] not in data_vars[field]['coords'][dim]:
-                                    data_vars[field]['coords']['T'].append(date_coord[1])
-                                    data_vars[field]['coords']['Ti'].append(date_coord[0])
-                                    data_vars[field]['coords']['Tf'].append(date_coord[2])
-                        elif dim == 'S':
+                                if date_coord[1] not in data_vars[field]["coords"][dim]:
+                                    data_vars[field]["coords"]["T"].append(
+                                        date_coord[1]
+                                    )
+                                    data_vars[field]["coords"]["Ti"].append(
+                                        date_coord[0]
+                                    )
+                                    data_vars[field]["coords"]["Tf"].append(
+                                        date_coord[2]
+                                    )
+                        elif dim == "S":
                             date_coord = read_cpt_date(header[2][dim])[0]
-                            if date_coord not in data_vars[field]['coords'][dim]:
-                                data_vars[field]['coords'][dim].append(date_coord)
+                            if date_coord not in data_vars[field]["coords"][dim]:
+                                data_vars[field]["coords"][dim].append(date_coord)
                         else:
-                            if header[2][dim] not in data_vars[field]['coords'][dim]:
-                                data_vars[field]['coords'][dim].append(header[2][dim])
-                if ndims == 3: 
-                    data_vars[field]['data'] = np.concatenate((data_vars[field]['data'], np.expand_dims(data, axis=0)), axis=0)
-                elif ndims == 4: 
-                    assert 'C' in header[2].keys() or 'M' in header[2].keys(), 'Only accomodating 4D data with a C (or M) dimension as the highest dimension right now - its coord must change in every header'
-                    if 'C' in header[2].keys():
-                        if len(data_vars[field]['data']) <= int(float(header[2]['C'])) -1: 
-                            data_vars[field]['data'].append(np.expand_dims(data, axis=0))
+                            if header[2][dim] not in data_vars[field]["coords"][dim]:
+                                data_vars[field]["coords"][dim].append(header[2][dim])
+                if ndims == 3:
+                    data_vars[field]["data"] = np.concatenate(
+                        (data_vars[field]["data"], np.expand_dims(data, axis=0)), axis=0
+                    )
+                elif ndims == 4:
+                    assert (
+                        "C" in header[2].keys() or "M" in header[2].keys()
+                    ), "Only accomodating 4D data with a C (or M) dimension as the highest dimension right now - its coord must change in every header"
+                    if "C" in header[2].keys():
+                        if (
+                            len(data_vars[field]["data"])
+                            <= int(float(header[2]["C"])) - 1
+                        ):
+                            data_vars[field]["data"].append(
+                                np.expand_dims(data, axis=0)
+                            )
                         else:
-                            data_vars[field]['data'][int(float(header[2]['C'])) -1] = np.concatenate((data_vars[field]['data'][int(float(header[2]['C'])) -1], np.expand_dims(data, axis=0)), axis=0)
-                    if 'M' in header[2].keys():
-                        if len(data_vars[field]['data']) <= int(float(header[2]['M'])) -1: 
-                            data_vars[field]['data'].append(np.expand_dims(data, axis=0))
+                            data_vars[field]["data"][
+                                int(float(header[2]["C"])) - 1
+                            ] = np.concatenate(
+                                (
+                                    data_vars[field]["data"][
+                                        int(float(header[2]["C"])) - 1
+                                    ],
+                                    np.expand_dims(data, axis=0),
+                                ),
+                                axis=0,
+                            )
+                    if "M" in header[2].keys():
+                        if (
+                            len(data_vars[field]["data"])
+                            <= int(float(header[2]["M"])) - 1
+                        ):
+                            data_vars[field]["data"].append(
+                                np.expand_dims(data, axis=0)
+                            )
                         else:
-                            data_vars[field]['data'][int(float(header[2]['M'])) -1] = np.concatenate((data_vars[field]['data'][int(float(header[2]['M'])) -1], np.expand_dims(data, axis=0)), axis=0)
+                            data_vars[field]["data"][
+                                int(float(header[2]["M"])) - 1
+                            ] = np.concatenate(
+                                (
+                                    data_vars[field]["data"][
+                                        int(float(header[2]["M"])) - 1
+                                    ],
+                                    np.expand_dims(data, axis=0),
+                                ),
+                                axis=0,
+                            )
 
-                data_vars[field]['attrs'].update(attrs)
-    #print(data_vars['attributes']['coords'])
+                data_vars[field]["attrs"].update(attrs)
+    # print(data_vars['attributes']['coords'])
 
     for field in data_vars.keys():
-        if len(data_vars[field]['dims']) == 4: 
-            data_vars[field]['data'] = np.concatenate([np.expand_dims(data_vars[field]['data'][k], axis=0) for k in range(len(data_vars[field]['data']))], axis=0)
+        if len(data_vars[field]["dims"]) == 4:
+            data_vars[field]["data"] = np.concatenate(
+                [
+                    np.expand_dims(data_vars[field]["data"][k], axis=0)
+                    for k in range(len(data_vars[field]["data"]))
+                ],
+                axis=0,
+            )
     for f in data_vars.keys():
-        data_vars[f]['coords'] = { m: ('T' if m in ['S', 'Ti', 'Tf'] else m, data_vars[f]['coords'][m]) for m in data_vars[f]['coords'].keys() }
-    dataarrays = {f.replace(' ', '_'): xr.DataArray(data_vars[f]['data'], dims=data_vars[f]['dims'], coords=data_vars[f]['coords'], attrs=data_vars[f]['attrs']) for f in data_vars.keys()}
-    for k in dataarrays.keys(): 
+        data_vars[f]["coords"] = {
+            m: ("T" if m in ["S", "Ti", "Tf"] else m, data_vars[f]["coords"][m])
+            for m in data_vars[f]["coords"].keys()
+        }
+    dataarrays = {
+        f.replace(" ", "_"): xr.DataArray(
+            data_vars[f]["data"],
+            dims=data_vars[f]["dims"],
+            coords=data_vars[f]["coords"],
+            attrs=data_vars[f]["attrs"],
+        )
+        for f in data_vars.keys()
+    }
+    for k in dataarrays.keys():
         is_valid_cptv10(dataarrays[k], assert_units=False, assertmissing=False)
-        if 'missing' in dataarrays[k].attrs.keys(): 
-            dataarrays[k] = dataarrays[k].where(dataarrays[k] != float(dataarrays[k].attrs['missing']), other=np.nan)
+        if "missing" in dataarrays[k].attrs.keys():
+            dataarrays[k] = dataarrays[k].where(
+                dataarrays[k] != float(dataarrays[k].attrs["missing"]), other=np.nan
+            )
     return xr.Dataset(dataarrays)
 
+
 def datetime_timestamp(date):
-    if 'T' in date: 
-        ymd, hms = date.split('T')
+    if "T" in date:
+        ymd, hms = date.split("T")
     else:
         ymd = date
 
-    fields = [int(i) for i in ymd.split('-')]
-    while len(fields) < 3: 
+    fields = [int(i) for i in ymd.split("-")]
+    while len(fields) < 3:
         fields.append(1)
     return dt.datetime(*fields)
 
 
 def datetime_timestamp_end(date):
-    if 'T' in date: 
-        ymd, hms = date.split('T')
+    if "T" in date:
+        ymd, hms = date.split("T")
     else:
         ymd = date
     last_days = [None, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-    fields = [int(i) for i in ymd.split('-')]
-    while len(fields) < 3: 
-        if len(fields) == 1: 
+    fields = [int(i) for i in ymd.split("-")]
+    while len(fields) < 3:
+        if len(fields) == 1:
             fields.append(12)
         else:
             fields.append(last_days[fields[1]])
     return dt.datetime(*fields)
-    
+
 
 def read_cpt_date(date_original):
-    if '/' in date_original: 
-        date1, date2 = date_original.split('/')
-        date1, date2 = date1.split('T')[0], date2.split('T')[0]
-        date1, date2 = date1.split(' ')[0], date2.split(' ')[0]
-        if len(date1.split('-')) == len(date2.split('-')): 
+    if "/" in date_original:
+        date1, date2 = date_original.split("/")
+        date1, date2 = date1.split("T")[0], date2.split("T")[0]
+        date1, date2 = date1.split(" ")[0], date2.split(" ")[0]
+        if len(date1.split("-")) == len(date2.split("-")):
             ret1, ret2 = datetime_timestamp(date1), datetime_timestamp_end(date2)
-        else: 
-            assert len(date1.split('-')) > len(date2.split('-')), 'date1 must have more elements than date2' 
-            ymd = date1.split('-') 
-            ymd2 = date2.split('-')
-            ymd2= ymd[:len(ymd) - len(ymd2)] + ymd2
-            ret1, ret2 = datetime_timestamp(date1), datetime_timestamp_end('-'.join(ymd2) if len(ymd2) > 1 else ymd2[0])
-        return [ ret1, ret1 + (ret2 - ret1) / 2, ret2]
-    else: 
-        return [datetime_timestamp(date_original)] 
+        else:
+            assert len(date1.split("-")) > len(
+                date2.split("-")
+            ), "date1 must have more elements than date2"
+            ymd = date1.split("-")
+            ymd2 = date2.split("-")
+            ymd2 = ymd[: len(ymd) - len(ymd2)] + ymd2
+            ret1, ret2 = datetime_timestamp(date1), datetime_timestamp_end(
+                "-".join(ymd2) if len(ymd2) > 1 else ymd2[0]
+            )
+        return [ret1, ret1 + (ret2 - ret1) / 2, ret2]
+    else:
+        return [datetime_timestamp(date_original)]
+
 
 def convert_np64_datetime(np64):
-    unix_epoch = np.datetime64(0, 's')
-    one_second = np.timedelta64(1, 's')
+    unix_epoch = np.datetime64(0, "s")
+    one_second = np.timedelta64(1, "s")
     seconds_since_epoch = (np64 - unix_epoch) / one_second
     return dt.datetime.utcfromtimestamp(seconds_since_epoch)
 
-def guess_cptv10_coords(da, row=None, col=None, T=None, C=None): 
-    ret = {'row': row, 'col': col, 'T': T, 'C': C} 
+
+def guess_cptv10_coords(da, row=None, col=None, T=None, C=None):
+    ret = {"row": row, "col": col, "T": T, "C": C}
     guesses = {
-        'row': ['Y', 'T', 'Mode'],
-        'col': ['X', 'index'],
-        'T': ['T', 'Mode'],
-        'C': ['C', 'M']
+        "row": ["Y", "T", "Mode"],
+        "col": ["X", "index"],
+        "T": ["T", "Mode"],
+        "C": ["C", "M"],
     }
     found = []
-    for dim in ['row', 'col', 'T', 'C']: 
+    for dim in ["row", "col", "T", "C"]:
         for guess in guesses[dim]:
-            if guess in da.dims and ret[dim] is None and guess not in found: 
-                ret[dim] = guess 
+            if guess in da.dims and ret[dim] is None and guess not in found:
+                ret[dim] = guess
                 found.append(guess)
     guesses = [ret[i] for i in ret.keys() if ret[i] is not None]
     found_dims = []
-    while len(guesses) > 0: 
+    while len(guesses) > 0:
         guess = guesses.pop(0)
-        assert guess not in found_dims, "repeated dimension in guesses (None excluded)- {}".format(ret)
+        assert (
+            guess not in found_dims
+        ), "repeated dimension in guesses (None excluded)- {}".format(ret)
         found_dims.append(guess)
-    assert len(found_dims) == len(da.dims), "Unable to guess names of all dims on da accurately - guessed {} vs {}".format(ret, da.dims)
+    assert len(found_dims) == len(
+        da.dims
+    ), "Unable to guess names of all dims on da accurately - guessed {} vs {}".format(
+        ret, da.dims
+    )
     for dim in found_dims:
-        assert dim in da.dims, "guessed a dimension not present on da - {} vs {}".format(ret, da.dims)
-    return ret['row'], ret['col'], ret['T'], ret['C']
+        assert (
+            dim in da.dims
+        ), "guessed a dimension not present on da - {} vs {}".format(ret, da.dims)
+    return ret["row"], ret["col"], ret["T"], ret["C"]
 
-def to_cptv10(da, opfile='cptv10.tsv', row=None, col=None, T=None, C=None, assertmissing=True, assert_units=True):
+
+def to_cptv10(
+    da,
+    opfile="cptv10.tsv",
+    row=None,
+    col=None,
+    T=None,
+    C=None,
+    assertmissing=True,
+    assert_units=True,
+):
     row, col, T, C = guess_cptv10_coords(da, row, col, T, C)
     is_valid_cptv10(da, assert_units=assert_units, assertmissing=assertmissing)
-    assert type(da) == xr.DataArray, 'Can only write Xr.DataArray to CPTv10'
-    extra_dims = [ i for i in [T, C] if i is not None ]
-    assert row is not None and col is not None, 'CPTv10 datasets must have at least two dimensions'
-    dims  = extra_dims + [row, col]
-    for dim in dims: 
-        assert dim in da.dims, 'missing dim from data array - {}'.format(dim)
-        assert dim in da.coords.keys(), 'missing coordinate from data array - {}'.format(dim)
-        assert len(da.coords[dim].values) == da.shape[list(da.dims).index(dim)], 'data array coord {} not the same size as the dimension'.format(dim)
-    assert len(dims) == len(da.dims), f'Data Array has dims {da.dims}, but you only passed {dims}'
-    missingblurb = ", cpt:missing={:.6f}".format(float(da.attrs['missing'])) if assertmissing else ''
-    unitsblurb = f", cpt:units={da.attrs['units']}" if assert_units else ''
-    with open(opfile, 'w') as f: 
-        f.write('xmlns:cpt=http://iri.columbia.edu/CPT/v10/' + "\n")
-        f.write('cpt:nfields=1'+"\n")
-        if C is not None: 
-            f.write(f'cpt:ncats={da.shape[list(da.dims).index(C)]}\n')
-        if len(extra_dims) == 2: 
+    assert type(da) == xr.DataArray, "Can only write Xr.DataArray to CPTv10"
+    extra_dims = [i for i in [T, C] if i is not None]
+    assert (
+        row is not None and col is not None
+    ), "CPTv10 datasets must have at least two dimensions"
+    dims = extra_dims + [row, col]
+    for dim in dims:
+        assert dim in da.dims, "missing dim from data array - {}".format(dim)
+        assert (
+            dim in da.coords.keys()
+        ), "missing coordinate from data array - {}".format(dim)
+        assert (
+            len(da.coords[dim].values) == da.shape[list(da.dims).index(dim)]
+        ), "data array coord {} not the same size as the dimension".format(dim)
+    assert len(dims) == len(
+        da.dims
+    ), f"Data Array has dims {da.dims}, but you only passed {dims}"
+    missingblurb = (
+        ", cpt:missing={:.6f}".format(float(da.attrs["missing"]))
+        if assertmissing
+        else ""
+    )
+    unitsblurb = f", cpt:units={da.attrs['units']}" if assert_units else ""
+    with open(opfile, "w") as f:
+        f.write("xmlns:cpt=http://iri.columbia.edu/CPT/v10/" + "\n")
+        f.write("cpt:nfields=1" + "\n")
+        if C is not None:
+            f.write(f"cpt:ncats={da.shape[list(da.dims).index(C)]}\n")
+        if len(extra_dims) == 2:
             da = da.transpose(T, C, row, col)
             for i in range(da.shape[list(da.dims).index(T)]):
                 for j in range(da.shape[list(da.dims).index(C)]):
-                    
+
                     header = f"cpt:field={da.name}, cpt:{T}={da.coords[T].values[i] if 'Ti' not in da.coords else '{}-{}-{}/{}-{}-{}'.format(convert_np64_datetime(da.coords['Ti'].values[i]).year, convert_np64_datetime(da.coords['Ti'].values[i]).month, convert_np64_datetime(da.coords['Ti'].values[i]).day, convert_np64_datetime(da.coords['Tf'].values[i]).year, convert_np64_datetime(da.coords['Tf'].values[i]).month, convert_np64_datetime(da.coords['Tf'].values[i]).day ) },{'' if 'S' not in da.coords.keys() else 'cpt:S='+ convert_np64_datetime(da.coords['S'].values[i]).strftime('%Y-%m-%dT%H:%M') + ', '} cpt:{C}={da.coords[C].values[j]}{', cpt:clim_prob=0.33333' if C=='C' else ''}, cpt:nrow={da.shape[list(da.dims).index(row)]}, cpt:ncol={da.shape[list(da.dims).index(col)]}, cpt:row={row}, cpt:col={col}{unitsblurb}{missingblurb}\n"
                     if assertmissing:
-                        temp = da.isel({T:i, C:j}).fillna(float(da.attrs['missing'])).values
+                        temp = (
+                            da.isel({T: i, C: j})
+                            .fillna(float(da.attrs["missing"]))
+                            .values
+                        )
                     else:
-                        temp = da.isel({T:i, C:j}).values
+                        temp = da.isel({T: i, C: j}).values
 
                     f.write(header)
-                    if row =='T' or col == 'T':
-                        tcoords_temp = [ (convert_np64_datetime(da.T.coords['Ti'].values[i]).year, convert_np64_datetime(da.T.coords['Ti'].values[i]).month, convert_np64_datetime(da.T.coords['Ti'].values[i]).day, convert_np64_datetime(da.T.coords['Tf'].values[i]).year, convert_np64_datetime(da.T.coords['Tf'].values[i]).month, convert_np64_datetime(da.T.coords['Tf'].values[i]).day) for i in range(da.shape[list(da.dims).index('T')]) ] 
+                    if row == "T" or col == "T":
+                        tcoords_temp = [
+                            (
+                                convert_np64_datetime(da.T.coords["Ti"].values[i]).year,
+                                convert_np64_datetime(
+                                    da.T.coords["Ti"].values[i]
+                                ).month,
+                                convert_np64_datetime(da.T.coords["Ti"].values[i]).day,
+                                convert_np64_datetime(da.T.coords["Tf"].values[i]).year,
+                                convert_np64_datetime(
+                                    da.T.coords["Tf"].values[i]
+                                ).month,
+                                convert_np64_datetime(da.T.coords["Tf"].values[i]).day,
+                            )
+                            for i in range(da.shape[list(da.dims).index("T")])
+                        ]
                         tcoords = ["{}-{}-{}/{}-{}-{}".format(*i) for i in tcoords_temp]
-                        tcoords = np.asarray(tcoords, dtype='object')
-                    if col != 'T':
-                        f.write('\t' + '\t'.join([str(crd) for crd in da.coords[col].values]) + '\n')
+                        tcoords = np.asarray(tcoords, dtype="object")
+                    if col != "T":
+                        f.write(
+                            "\t"
+                            + "\t".join([str(crd) for crd in da.coords[col].values])
+                            + "\n"
+                        )
                     else:
-                        f.write('\t' + '\t'.join([str(crd) for crd in tcoords]) + '\n')
-                    if row != 'T':
-                        temp = np.hstack([da.coords[row].values.reshape(-1,1), temp])
+                        f.write("\t" + "\t".join([str(crd) for crd in tcoords]) + "\n")
+                    if row != "T":
+                        temp = np.hstack([da.coords[row].values.reshape(-1, 1), temp])
                     else:
-                        temp = np.hstack([tcoords.reshape(-1,1), temp.astype('object')])
-                    if row != 'T':
-                        np.savetxt(f, temp, fmt="%.6f", delimiter='\t')
-                    else: 
-                        np.savetxt(f, temp, fmt="%s", delimiter='\t')
-        elif len(extra_dims) == 1 and T is not None: 
+                        temp = np.hstack(
+                            [tcoords.reshape(-1, 1), temp.astype("object")]
+                        )
+                    if row != "T":
+                        np.savetxt(f, temp, fmt="%.6f", delimiter="\t")
+                    else:
+                        np.savetxt(f, temp, fmt="%s", delimiter="\t")
+        elif len(extra_dims) == 1 and T is not None:
             da = da.transpose(T, row, col)
             for i in range(da.shape[list(da.dims).index(T)]):
                 header = f"cpt:field={da.name}, cpt:{T}={da.coords[T].values[i] if 'Ti' not in da.coords else '{}-{}-{}/{}-{}-{}'.format(convert_np64_datetime(da.coords['Ti'].values[i]).year, convert_np64_datetime(da.coords['Ti'].values[i]).month, convert_np64_datetime(da.coords['Ti'].values[i]).day, convert_np64_datetime(da.coords['Tf'].values[i]).year, convert_np64_datetime(da.coords['Tf'].values[i]).month, convert_np64_datetime(da.coords['Tf'].values[i]).day ) },{'' if 'S' not in da.coords.keys() else ' cpt:S='+ convert_np64_datetime(da.coords['S'].values[i]).strftime('%Y-%m-%dT%H:%M') + ', '} cpt:nrow={da.shape[list(da.dims).index(row)]}, cpt:ncol={da.shape[list(da.dims).index(col)]}, cpt:row={row}, cpt:col={col}{unitsblurb}{missingblurb}\n"
                 if assertmissing:
-                    temp = da.isel({T:i}).fillna(float(da.attrs['missing'])).values
+                    temp = da.isel({T: i}).fillna(float(da.attrs["missing"])).values
                 else:
-                    temp = da.isel({T:i}).values
+                    temp = da.isel({T: i}).values
                 f.write(header)
-                if row =='T' or col == 'T':
-                        tcoords_temp = [ (convert_np64_datetime(da.T.coords['Ti'].values[i]).year, convert_np64_datetime(da.T.coords['Ti'].values[i]).month, convert_np64_datetime(da.T.coords['Ti'].values[i]).day, convert_np64_datetime(da.T.coords['Tf'].values[i]).year, convert_np64_datetime(da.T.coords['Tf'].values[i]).month, convert_np64_datetime(da.T.coords['Tf'].values[i]).day) for i in range(da.shape[list(da.dims).index('T')]) ] 
-                        tcoords = ["{}-{}-{}/{}-{}-{}".format(*i) for i in tcoords_temp]
-                        tcoords = np.asarray(tcoords, dtype='object')
-                if col != 'T':
-                    f.write('\t' + '\t'.join([str(crd) for crd in da.coords[col].values]) + '\n')
+                if row == "T" or col == "T":
+                    tcoords_temp = [
+                        (
+                            convert_np64_datetime(da.T.coords["Ti"].values[i]).year,
+                            convert_np64_datetime(da.T.coords["Ti"].values[i]).month,
+                            convert_np64_datetime(da.T.coords["Ti"].values[i]).day,
+                            convert_np64_datetime(da.T.coords["Tf"].values[i]).year,
+                            convert_np64_datetime(da.T.coords["Tf"].values[i]).month,
+                            convert_np64_datetime(da.T.coords["Tf"].values[i]).day,
+                        )
+                        for i in range(da.shape[list(da.dims).index("T")])
+                    ]
+                    tcoords = ["{}-{}-{}/{}-{}-{}".format(*i) for i in tcoords_temp]
+                    tcoords = np.asarray(tcoords, dtype="object")
+                if col != "T":
+                    f.write(
+                        "\t"
+                        + "\t".join([str(crd) for crd in da.coords[col].values])
+                        + "\n"
+                    )
                 else:
-                    f.write('\t' + '\t'.join([str(crd) for crd in tcoords]) + '\n')
-                if row != 'T':
-                    temp = np.hstack([da.coords[row].values.reshape(-1,1), temp])
+                    f.write("\t" + "\t".join([str(crd) for crd in tcoords]) + "\n")
+                if row != "T":
+                    temp = np.hstack([da.coords[row].values.reshape(-1, 1), temp])
                 else:
-                    temp = np.hstack([tcoords.reshape(-1,1), temp.astype('object')])
-                if row != 'T':
-                    np.savetxt(f, temp, fmt="%.6f", delimiter='\t')
-                else: 
-                    np.savetxt(f, temp, fmt="%s", delimiter='\t')
+                    temp = np.hstack([tcoords.reshape(-1, 1), temp.astype("object")])
+                if row != "T":
+                    np.savetxt(f, temp, fmt="%.6f", delimiter="\t")
+                else:
+                    np.savetxt(f, temp, fmt="%s", delimiter="\t")
 
-        elif len(extra_dims) == 1 and C is not None: 
+        elif len(extra_dims) == 1 and C is not None:
             da = da.transpose(C, row, col)
             for j in range(da.shape[list(da.dims).index(C)]):
                 header = f"cpt:field={da.name}, cpt:{C}={da.coords[C].values[j]}{', cpt:clim_prob=0.33333' if C=='C' else ''}, cpt:nrow={da.shape[list(da.dims).index(row)]}, cpt:ncol={da.shape[list(da.dims).index(col)]}, cpt:row={row}, cpt:col={col}{unitsblurb}{missingblurb}\n"
                 if assertmissing:
-                    temp = da.isel({C:j}).fillna(float(da.attrs['missing'])).values
+                    temp = da.isel({C: j}).fillna(float(da.attrs["missing"])).values
                 else:
-                    temp = da.isel({T:i}).values
+                    temp = da.isel({T: i}).values
                 f.write(header)
-                if row =='T' or col == 'T':
-                        tcoords_temp = [ (convert_np64_datetime(da.T.coords['Ti'].values[i]).year, convert_np64_datetime(da.T.coords['Ti'].values[i]).month, convert_np64_datetime(da.T.coords['Ti'].values[i]).day, convert_np64_datetime(da.T.coords['Tf'].values[i]).year, convert_np64_datetime(da.T.coords['Tf'].values[i]).month, convert_np64_datetime(da.T.coords['Tf'].values[i]).day) for i in range(da.shape[list(da.dims).index('T')]) ] 
-                        tcoords = ["{}-{}-{}/{}-{}-{}".format(*i) for i in tcoords_temp]
-                        tcoords = np.asarray(tcoords, dtype='object')
-                if col != 'T':
-                    f.write('\t' + '\t'.join([str(crd) for crd in da.coords[col].values]) + '\n')
+                if row == "T" or col == "T":
+                    tcoords_temp = [
+                        (
+                            convert_np64_datetime(da.T.coords["Ti"].values[i]).year,
+                            convert_np64_datetime(da.T.coords["Ti"].values[i]).month,
+                            convert_np64_datetime(da.T.coords["Ti"].values[i]).day,
+                            convert_np64_datetime(da.T.coords["Tf"].values[i]).year,
+                            convert_np64_datetime(da.T.coords["Tf"].values[i]).month,
+                            convert_np64_datetime(da.T.coords["Tf"].values[i]).day,
+                        )
+                        for i in range(da.shape[list(da.dims).index("T")])
+                    ]
+                    tcoords = ["{}-{}-{}/{}-{}-{}".format(*i) for i in tcoords_temp]
+                    tcoords = np.asarray(tcoords, dtype="object")
+                if col != "T":
+                    f.write(
+                        "\t"
+                        + "\t".join([str(crd) for crd in da.coords[col].values])
+                        + "\n"
+                    )
                 else:
-                    f.write('\t' + '\t'.join([str(crd) for crd in tcoords]) + '\n')
-                if row != 'T':
-                    temp = np.hstack([da.coords[row].values.reshape(-1,1), temp])
+                    f.write("\t" + "\t".join([str(crd) for crd in tcoords]) + "\n")
+                if row != "T":
+                    temp = np.hstack([da.coords[row].values.reshape(-1, 1), temp])
                 else:
-                    temp = np.hstack([tcoords.reshape(-1,1), temp.astype('object')])
-                if row != 'T':
-                    np.savetxt(f, temp, fmt="%.6f", delimiter='\t')
-                else: 
-                    np.savetxt(f, temp, fmt="%s", delimiter='\t')       
+                    temp = np.hstack([tcoords.reshape(-1, 1), temp.astype("object")])
+                if row != "T":
+                    np.savetxt(f, temp, fmt="%.6f", delimiter="\t")
+                else:
+                    np.savetxt(f, temp, fmt="%s", delimiter="\t")
         else:
             da = da.transpose(row, col)
             header = f"cpt:field={da.name}, cpt:nrow={da.shape[list(da.dims).index(row)]}, cpt:ncol={da.shape[list(da.dims).index(col)]}, cpt:row={row}, cpt:col={col}{unitsblurb}{missingblurb}\n"
             if assertmissing:
-                temp = da.fillna(float(da.attrs['missing'])).values
+                temp = da.fillna(float(da.attrs["missing"])).values
             else:
                 temp = da.values
             f.write(header)
-            if row =='T' or col == 'T':
-                tcoords_temp = [ (convert_np64_datetime(da.T.coords['Ti'].values[i]).year, convert_np64_datetime(da.T.coords['Ti'].values[i]).month, convert_np64_datetime(da.T.coords['Ti'].values[i]).day, convert_np64_datetime(da.T.coords['Tf'].values[i]).year, convert_np64_datetime(da.T.coords['Tf'].values[i]).month, convert_np64_datetime(da.T.coords['Tf'].values[i]).day) for i in range(da.shape[list(da.dims).index('T')]) ] 
+            if row == "T" or col == "T":
+                tcoords_temp = [
+                    (
+                        convert_np64_datetime(da.T.coords["Ti"].values[i]).year,
+                        convert_np64_datetime(da.T.coords["Ti"].values[i]).month,
+                        convert_np64_datetime(da.T.coords["Ti"].values[i]).day,
+                        convert_np64_datetime(da.T.coords["Tf"].values[i]).year,
+                        convert_np64_datetime(da.T.coords["Tf"].values[i]).month,
+                        convert_np64_datetime(da.T.coords["Tf"].values[i]).day,
+                    )
+                    for i in range(da.shape[list(da.dims).index("T")])
+                ]
                 tcoords = ["{}-{}-{}/{}-{}-{}".format(*i) for i in tcoords_temp]
-                tcoords = np.asarray(tcoords, dtype='object')
-            if col != 'T':
-                f.write('\t' + '\t'.join([str(crd) for crd in da.coords[col].values]) + '\n')
+                tcoords = np.asarray(tcoords, dtype="object")
+            if col != "T":
+                f.write(
+                    "\t" + "\t".join([str(crd) for crd in da.coords[col].values]) + "\n"
+                )
             else:
-                f.write('\t' + '\t'.join([str(crd) for crd in tcoords]) + '\n')
-            if row != 'T':
-                temp = np.hstack([da.coords[row].values.reshape(-1,1), temp])
+                f.write("\t" + "\t".join([str(crd) for crd in tcoords]) + "\n")
+            if row != "T":
+                temp = np.hstack([da.coords[row].values.reshape(-1, 1), temp])
             else:
-                temp = np.hstack([tcoords.reshape(-1,1), temp.astype('object')])
-            if row != 'T':
-                np.savetxt(f, temp, fmt="%.6f", delimiter='\t')
-            else: 
-                np.savetxt(f, temp, fmt="%s", delimiter='\t')
+                temp = np.hstack([tcoords.reshape(-1, 1), temp.astype("object")])
+            if row != "T":
+                np.savetxt(f, temp, fmt="%.6f", delimiter="\t")
+            else:
+                np.savetxt(f, temp, fmt="%s", delimiter="\t")
     return opfile
-
-               
-
-
-
-

--- a/src/cptio/fileio/cpt.py
+++ b/src/cptio/fileio/cpt.py
@@ -21,32 +21,40 @@ def is_valid_cptv10(da, assertmissing=True, assert_units=True):
         assert (
             dim in da.coords
         ), "Each dim on a CPTv10 must have corresponding coordinates"
-        assert (
-            len(da.coords[dim].values) == da.shape[list(da.dims).index(dim)]
-        ), "Each dim on a CPTv10 must have exactly one coordinate per index along that dimension"
+        assert len(da.coords[dim].values) == da.shape[list(da.dims).index(dim)], (
+            "Each dim on a CPTv10 must have exactly one coordinate per index along that"
+            " dimension"
+        )
     if "T" in da.dims:
         for dim in ["Ti", "Tf", "S"]:
             if dim in da.coords:
                 assert (
                     len(da.coords[dim].values) == da.shape[list(da.dims).index("T")]
-                ), "If the CPTv10 has optional Time coordinates Ti, Tf, or S, they must be indexing the T dimension"
+                ), (
+                    "If the CPTv10 has optional Time coordinates Ti, Tf, or S, they"
+                    " must be indexing the T dimension"
+                )
     for dim in ["Ti", "Tf", "S"]:
         if dim in da.dims:
-            assert (
-                "T" in da.dims
-            ), "if the optional time coordinates are present on the CPTv10, the required time coord must also be"
+            assert "T" in da.dims, (
+                "if the optional time coordinates are present on the CPTv10, the"
+                " required time coord must also be"
+            )
     if "Ti" in da.coords:
-        assert (
-            "Tf" in da.coords
-        ), "Cannot have one optional time coordinate and not the other. found Ti but not Tf. except for S"
+        assert "Tf" in da.coords, (
+            "Cannot have one optional time coordinate and not the other. found Ti but"
+            " not Tf. except for S"
+        )
     if "Tf" in da.coords:
-        assert (
-            "Ti" in da.coords
-        ), "Cannot have one optional time coordinate and not the other. found Tf but not Ti. except for S"
+        assert "Ti" in da.coords, (
+            "Cannot have one optional time coordinate and not the other. found Tf but"
+            " not Ti. except for S"
+        )
     if assertmissing:
-        assert (
-            "missing" in da.attrs.keys()
-        ), "CPTv10 is required to have a 'missing' attribute indicating the 'missing_value' value which replaces NaNs in CPT"
+        assert "missing" in da.attrs.keys(), (
+            "CPTv10 is required to have a 'missing' attribute indicating the"
+            " 'missing_value' value which replaces NaNs in CPT"
+        )
         assert not np.isnan(
             float(da.attrs["missing"])
         ), "CPTv10 Missing Value cannot be NaN"
@@ -240,9 +248,11 @@ def open_cptdataset(filename):
                         (data_vars[field]["data"], np.expand_dims(data, axis=0)), axis=0
                     )
                 elif ndims == 4:
-                    assert (
-                        "C" in header[2].keys() or "M" in header[2].keys()
-                    ), "Only accomodating 4D data with a C (or M) dimension as the highest dimension right now - its coord must change in every header"
+                    assert "C" in header[2].keys() or "M" in header[2].keys(), (
+                        "Only accomodating 4D data with a C (or M) dimension as the"
+                        " highest dimension right now - its coord must change in every"
+                        " header"
+                    )
                     if "C" in header[2].keys():
                         if (
                             len(data_vars[field]["data"])
@@ -453,8 +463,13 @@ def to_cptv10(
             da = da.transpose(T, C, row, col)
             for i in range(da.shape[list(da.dims).index(T)]):
                 for j in range(da.shape[list(da.dims).index(C)]):
-
-                    header = f"cpt:field={da.name}, cpt:{T}={da.coords[T].values[i] if 'Ti' not in da.coords else '{}-{}-{}/{}-{}-{}'.format(convert_np64_datetime(da.coords['Ti'].values[i]).year, convert_np64_datetime(da.coords['Ti'].values[i]).month, convert_np64_datetime(da.coords['Ti'].values[i]).day, convert_np64_datetime(da.coords['Tf'].values[i]).year, convert_np64_datetime(da.coords['Tf'].values[i]).month, convert_np64_datetime(da.coords['Tf'].values[i]).day ) },{'' if 'S' not in da.coords.keys() else 'cpt:S='+ convert_np64_datetime(da.coords['S'].values[i]).strftime('%Y-%m-%dT%H:%M') + ', '} cpt:{C}={da.coords[C].values[j]}{', cpt:clim_prob=0.33333' if C=='C' else ''}, cpt:nrow={da.shape[list(da.dims).index(row)]}, cpt:ncol={da.shape[list(da.dims).index(col)]}, cpt:row={row}, cpt:col={col}{unitsblurb}{missingblurb}\n"
+                    header = (
+                        f"cpt:field={da.name},"
+                        f" cpt:{T}={da.coords[T].values[i] if 'Ti' not in da.coords else '{}-{}-{}/{}-{}-{}'.format(convert_np64_datetime(da.coords['Ti'].values[i]).year, convert_np64_datetime(da.coords['Ti'].values[i]).month, convert_np64_datetime(da.coords['Ti'].values[i]).day, convert_np64_datetime(da.coords['Tf'].values[i]).year, convert_np64_datetime(da.coords['Tf'].values[i]).month, convert_np64_datetime(da.coords['Tf'].values[i]).day ) },{'' if 'S' not in da.coords.keys() else 'cpt:S='+ convert_np64_datetime(da.coords['S'].values[i]).strftime('%Y-%m-%dT%H:%M') + ', '} cpt:{C}={da.coords[C].values[j]}{', cpt:clim_prob=0.33333' if C=='C' else ''},"
+                        f" cpt:nrow={da.shape[list(da.dims).index(row)]},"
+                        f" cpt:ncol={da.shape[list(da.dims).index(col)]},"
+                        f" cpt:row={row}, cpt:col={col}{unitsblurb}{missingblurb}\n"
+                    )
                     if assertmissing:
                         temp = (
                             da.isel({T: i, C: j})
@@ -504,7 +519,12 @@ def to_cptv10(
         elif len(extra_dims) == 1 and T is not None:
             da = da.transpose(T, row, col)
             for i in range(da.shape[list(da.dims).index(T)]):
-                header = f"cpt:field={da.name}, cpt:{T}={da.coords[T].values[i] if 'Ti' not in da.coords else '{}-{}-{}/{}-{}-{}'.format(convert_np64_datetime(da.coords['Ti'].values[i]).year, convert_np64_datetime(da.coords['Ti'].values[i]).month, convert_np64_datetime(da.coords['Ti'].values[i]).day, convert_np64_datetime(da.coords['Tf'].values[i]).year, convert_np64_datetime(da.coords['Tf'].values[i]).month, convert_np64_datetime(da.coords['Tf'].values[i]).day ) },{'' if 'S' not in da.coords.keys() else ' cpt:S='+ convert_np64_datetime(da.coords['S'].values[i]).strftime('%Y-%m-%dT%H:%M') + ', '} cpt:nrow={da.shape[list(da.dims).index(row)]}, cpt:ncol={da.shape[list(da.dims).index(col)]}, cpt:row={row}, cpt:col={col}{unitsblurb}{missingblurb}\n"
+                header = (
+                    f"cpt:field={da.name},"
+                    f" cpt:{T}={da.coords[T].values[i] if 'Ti' not in da.coords else '{}-{}-{}/{}-{}-{}'.format(convert_np64_datetime(da.coords['Ti'].values[i]).year, convert_np64_datetime(da.coords['Ti'].values[i]).month, convert_np64_datetime(da.coords['Ti'].values[i]).day, convert_np64_datetime(da.coords['Tf'].values[i]).year, convert_np64_datetime(da.coords['Tf'].values[i]).month, convert_np64_datetime(da.coords['Tf'].values[i]).day ) },{'' if 'S' not in da.coords.keys() else ' cpt:S='+ convert_np64_datetime(da.coords['S'].values[i]).strftime('%Y-%m-%dT%H:%M') + ', '} cpt:nrow={da.shape[list(da.dims).index(row)]},"
+                    f" cpt:ncol={da.shape[list(da.dims).index(col)]}, cpt:row={row},"
+                    f" cpt:col={col}{unitsblurb}{missingblurb}\n"
+                )
                 if assertmissing:
                     temp = da.isel({T: i}).fillna(float(da.attrs["missing"])).values
                 else:
@@ -544,7 +564,13 @@ def to_cptv10(
         elif len(extra_dims) == 1 and C is not None:
             da = da.transpose(C, row, col)
             for j in range(da.shape[list(da.dims).index(C)]):
-                header = f"cpt:field={da.name}, cpt:{C}={da.coords[C].values[j]}{', cpt:clim_prob=0.33333' if C=='C' else ''}, cpt:nrow={da.shape[list(da.dims).index(row)]}, cpt:ncol={da.shape[list(da.dims).index(col)]}, cpt:row={row}, cpt:col={col}{unitsblurb}{missingblurb}\n"
+                header = (
+                    f"cpt:field={da.name},"
+                    f" cpt:{C}={da.coords[C].values[j]}{', cpt:clim_prob=0.33333' if C=='C' else ''},"
+                    f" cpt:nrow={da.shape[list(da.dims).index(row)]},"
+                    f" cpt:ncol={da.shape[list(da.dims).index(col)]}, cpt:row={row},"
+                    f" cpt:col={col}{unitsblurb}{missingblurb}\n"
+                )
                 if assertmissing:
                     temp = da.isel({C: j}).fillna(float(da.attrs["missing"])).values
                 else:
@@ -582,7 +608,11 @@ def to_cptv10(
                     np.savetxt(f, temp, fmt="%s", delimiter="\t")
         else:
             da = da.transpose(row, col)
-            header = f"cpt:field={da.name}, cpt:nrow={da.shape[list(da.dims).index(row)]}, cpt:ncol={da.shape[list(da.dims).index(col)]}, cpt:row={row}, cpt:col={col}{unitsblurb}{missingblurb}\n"
+            header = (
+                f"cpt:field={da.name}, cpt:nrow={da.shape[list(da.dims).index(row)]},"
+                f" cpt:ncol={da.shape[list(da.dims).index(col)]}, cpt:row={row},"
+                f" cpt:col={col}{unitsblurb}{missingblurb}\n"
+            )
             if assertmissing:
                 temp = da.fillna(float(da.attrs["missing"])).values
             else:

--- a/src/cptio/utilities/__init__.py
+++ b/src/cptio/utilities/__init__.py
@@ -1,4 +1,4 @@
-from .utilities import * 
+from .utilities import *
 from .bash import *
-from .targetleadconv import * 
-from .verify import * 
+from .targetleadconv import *
+from .verify import *

--- a/src/cptio/utilities/bash.py
+++ b/src/cptio/utilities/bash.py
@@ -1,29 +1,31 @@
-### General Purpose Utilities 
+### General Purpose Utilities
 def rmrf(dirn):
-    subfiles = [file for file in dirn.glob('*') if file.is_file()]
-    subdirs = [diro for diro in dirn.glob('*') if diro.is_dir()]
+    subfiles = [file for file in dirn.glob("*") if file.is_file()]
+    subdirs = [diro for diro in dirn.glob("*") if diro.is_dir()]
 
-    for file in subfiles: 
+    for file in subfiles:
         file.chmod(0o0777)
-        file.unlink() 
-    for subdir in subdirs: 
-        try: 
+        file.unlink()
+    for subdir in subdirs:
+        try:
             subdir.chmod(0o0777)
-            subdir.rmdir() 
-        except: 
+            subdir.rmdir()
+        except:
             rmrf(subdir)
-    dirn.rmdir() 
+    dirn.rmdir()
+
 
 def rmstar(dirn):
-    subfiles = [file for file in dirn.glob('*') if file.is_file()]
-    for file in subfiles: 
+    subfiles = [file for file in dirn.glob("*") if file.is_file()]
+    for file in subfiles:
         file.chmod(0o0777)
-        file.unlink() 
+        file.unlink()
+
 
 def ls_files_recursive(dirn):
-    subfiles = [file for file in dirn.glob('*') if file.is_file()]
-    subdirs = [diro for diro in dirn.glob('*') if diro.is_dir()]
-    files = [ file.absolute() for file in subfiles]
-    for subdir in subdirs: 
+    subfiles = [file for file in dirn.glob("*") if file.is_file()]
+    subdirs = [diro for diro in dirn.glob("*") if diro.is_dir()]
+    files = [file.absolute() for file in subfiles]
+    for subdir in subdirs:
         files.extend(ls_files_recursive(subdir))
     return files

--- a/src/cptio/utilities/targetleadconv.py
+++ b/src/cptio/utilities/targetleadconv.py
@@ -51,9 +51,10 @@ monthlengths = [0, 31, 28.25, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
 
 def parse_target(target):
     """Gets a numerical month from three-letter month abbreviations"""
-    assert ("-" in target and len(target) == 7) or len(
-        target
-    ) == 3, 'TARGET must be in three-letter format for one month, or a range of months. For example, "Jun" or "Jun-Jul"'
+    assert ("-" in target and len(target) == 7) or len(target) == 3, (
+        "TARGET must be in three-letter format for one month, or a range of months. For"
+        ' example, "Jun" or "Jun-Jul"'
+    )
     low, high = target.split("-") if "-" in target else (target, target)
     return threeletters.index(low), threeletters.index(high)
 
@@ -134,15 +135,13 @@ def seasonal_target(fdate, target, lead_low, lead_high):
         target is not None and lead_high is not None and lead_low is not None
     ):  # if all are supplied
         ll, lh = leads_from_target(fdate, target)
-        assert (
-            ll == lead_low
-        ), "Provided lead_low incompatible with provided target and fdate - calculated {} but given {}".format(
-            ll, lead_low
+        assert ll == lead_low, (
+            "Provided lead_low incompatible with provided target and fdate - calculated"
+            " {} but given {}".format(ll, lead_low)
         )
-        assert (
-            ll == lead_low
-        ), "Provided lead_high incompatible with provided target and fdate - calculated {} but given {}".format(
-            lh, lead_high
+        assert ll == lead_low, (
+            "Provided lead_high incompatible with provided target and fdate -"
+            " calculated {} but given {}".format(lh, lead_high)
         )
         return fdate, target, lead_low, lead_high
     elif (
@@ -156,9 +155,10 @@ def seasonal_target(fdate, target, lead_low, lead_high):
         target = target_from_leads(fdate, lead_low, lead_high)
         return fdate, target, lead_low, lead_high
     else:
-        assert (
-            False
-        ), "Must provide either a TARGET in three-letter format for one month, or a range of months, or a set of lead-times, or all three which agree"
+        assert False, (
+            "Must provide either a TARGET in three-letter format for one month, or a"
+            " range of months, or a set of lead-times, or all three which agree"
+        )
 
 
 def subx_target(target=None, lead_low=None, lead_high=None):
@@ -183,13 +183,15 @@ def subx_target(target=None, lead_low=None, lead_high=None):
         assert target in leads.keys(), "invalid subx target {}".format(target)
         lead_low, lead_high = leads[target]
     elif target is None and lead_low is not None and lead_high is None:
-        assert (
-            False
-        ), "must either provide a target, or both leads, or a set of all three which agree"
+        assert False, (
+            "must either provide a target, or both leads, or a set of all three which"
+            " agree"
+        )
     elif target is None and lead_low is None and lead_high is not None:
-        assert (
-            False
-        ), "must either provide a target, or both leads, or a set of all three which agree"
+        assert False, (
+            "must either provide a target, or both leads, or a set of all three which"
+            " agree"
+        )
     else:
         target = (
             lr[(lead_low, lead_high)]

--- a/src/cptio/utilities/targetleadconv.py
+++ b/src/cptio/utilities/targetleadconv.py
@@ -1,125 +1,223 @@
 import datetime as dt
 
-months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+months = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+]
 possible_targets = "JFMAMJJASONDJFMAMJJASOND"
 
+
 def find_target(target):
-    ndx = 0 
-    while possible_targets[ndx:ndx+len(target)] != target and ndx + len(target) <= 24:
-        ndx += 1 
+    ndx = 0
+    while (
+        possible_targets[ndx : ndx + len(target)] != target and ndx + len(target) <= 24
+    ):
+        ndx += 1
     assert ndx + len(target) <= 24, "{} Target Not Found".format(target)
     return months[ndx % 12], months[(ndx + len(target)) % 12 - 1]
-     
-def init_from_lead(lead, tstart):
-    return months[ (months.index(tstart) - lead) % 12 ]
 
-threeletters = [None, 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-monthlengths = [ 0, 31, 28.25, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+def init_from_lead(lead, tstart):
+    return months[(months.index(tstart) - lead) % 12]
+
+
+threeletters = [
+    None,
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+]
+monthlengths = [0, 31, 28.25, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+
 def parse_target(target):
     """Gets a numerical month from three-letter month abbreviations"""
-    assert ('-' in target and len(target) == 7) or len(target) == 3, 'TARGET must be in three-letter format for one month, or a range of months. For example, "Jun" or "Jun-Jul"'
-    low, high = target.split('-') if '-' in target else (target, target)
+    assert ("-" in target and len(target) == 7) or len(
+        target
+    ) == 3, 'TARGET must be in three-letter format for one month, or a range of months. For example, "Jun" or "Jun-Jul"'
+    low, high = target.split("-") if "-" in target else (target, target)
     return threeletters.index(low), threeletters.index(high)
+
 
 def leads_from_target(fdate, target):
     """calculates lead_low and lead_high"""
     target_low, target_high = parse_target(target)
-    #print(target_low, target_high, fdate.month)
-    lead_low = 12 - (fdate.month - target_low) + 0.5 if target_low < fdate.month else (target_low - fdate.month) + 0.5 
-    lead_high = 12 - (fdate.month - target_high) + 0.5 if target_high < fdate.month else (target_high - fdate.month) + 0.5 
-    #print(target_low, target_high, fdate.month, lead_low, lead_high)
+    # print(target_low, target_high, fdate.month)
+    lead_low = (
+        12 - (fdate.month - target_low) + 0.5
+        if target_low < fdate.month
+        else (target_low - fdate.month) + 0.5
+    )
+    lead_high = (
+        12 - (fdate.month - target_high) + 0.5
+        if target_high < fdate.month
+        else (target_high - fdate.month) + 0.5
+    )
+    # print(target_low, target_high, fdate.month, lead_low, lead_high)
 
     return lead_low, lead_high
 
+
 def target_from_leads(fdate, lead_low, lead_high):
-    low_ndx = fdate.month + int(lead_low) if fdate.month + int(lead_low) <= 12 else fdate.month + int(lead_low) - 12
-    high_ndx = fdate.month + int(lead_high) if fdate.month + int(lead_high) <= 12 else fdate.month + int(lead_high) - 12
+    low_ndx = (
+        fdate.month + int(lead_low)
+        if fdate.month + int(lead_low) <= 12
+        else fdate.month + int(lead_low) - 12
+    )
+    high_ndx = (
+        fdate.month + int(lead_high)
+        if fdate.month + int(lead_high) <= 12
+        else fdate.month + int(lead_high) - 12
+    )
     target_low = threeletters[low_ndx]
-    target_high = threeletters[high_ndx]  
-    return target_low if target_low == target_high else '{}_{}'.format(target_low, target_high)
+    target_high = threeletters[high_ndx]
+    return (
+        target_low
+        if target_low == target_high
+        else "{}_{}".format(target_low, target_high)
+    )
 
-def seasonal_target_length(target): 
-    # target must be three-letter-abbr style 
-    if '-' in target: 
+
+def seasonal_target_length(target):
+    # target must be three-letter-abbr style
+    if "-" in target:
         total = 0
-        start, end = target.split('-')
+        start, end = target.split("-")
         start_ndx, end_ndx = threeletters.index(start), threeletters.index(end)
-        if end_ndx < start_ndx: # cross-year 
+        if end_ndx < start_ndx:  # cross-year
             total += sum(monthlengths[start_ndx:])
-            total += sum(monthlengths[:end_ndx+1])
+            total += sum(monthlengths[: end_ndx + 1])
             return total
-        else: 
-            return sum(monthlengths[start_ndx:end_ndx+1])
-    else: 
+        else:
+            return sum(monthlengths[start_ndx : end_ndx + 1])
+    else:
         return monthlengths[threeletters.index(target)]
 
-def seasonal_target_length_monthly(target): 
-    # target must be three-letter-abbr style 
-    if '-' in target: 
+
+def seasonal_target_length_monthly(target):
+    # target must be three-letter-abbr style
+    if "-" in target:
         total = 0
-        start, end = target.split('-')
+        start, end = target.split("-")
         start_ndx, end_ndx = threeletters.index(start), threeletters.index(end)
-        if end_ndx < start_ndx: # cross-year 
+        if end_ndx < start_ndx:  # cross-year
             total += 12 - start_ndx + 1
-            total += end_ndx 
+            total += end_ndx
             return total
-        else: 
-            return end_ndx - start_ndx +1
-    else: 
+        else:
+            return end_ndx - start_ndx + 1
+    else:
         return monthlengths[threeletters.index(target)]
+
 
 def seasonal_target(fdate, target, lead_low, lead_high):
-    if target is not None and lead_high is not None and lead_low is not None: # if all are supplied
+    if (
+        target is not None and lead_high is not None and lead_low is not None
+    ):  # if all are supplied
         ll, lh = leads_from_target(fdate, target)
-        assert ll == lead_low, 'Provided lead_low incompatible with provided target and fdate - calculated {} but given {}'.format(ll, lead_low)
-        assert ll == lead_low, 'Provided lead_high incompatible with provided target and fdate - calculated {} but given {}'.format(lh, lead_high)
-        return fdate, target, lead_low, lead_high 
-    elif target is not None and lead_low is None and lead_high is None: # if we only get a target
+        assert (
+            ll == lead_low
+        ), "Provided lead_low incompatible with provided target and fdate - calculated {} but given {}".format(
+            ll, lead_low
+        )
+        assert (
+            ll == lead_low
+        ), "Provided lead_high incompatible with provided target and fdate - calculated {} but given {}".format(
+            lh, lead_high
+        )
+        return fdate, target, lead_low, lead_high
+    elif (
+        target is not None and lead_low is None and lead_high is None
+    ):  # if we only get a target
         ll, lh = leads_from_target(fdate, target)
-        return fdate, target, ll, lh 
-    elif target is None and lead_low is not None and lead_high is not None: # if we get leads and no target
+        return fdate, target, ll, lh
+    elif (
+        target is None and lead_low is not None and lead_high is not None
+    ):  # if we get leads and no target
         target = target_from_leads(fdate, lead_low, lead_high)
-        return fdate, target, lead_low, lead_high 
-    else: 
-        assert False, 'Must provide either a TARGET in three-letter format for one month, or a range of months, or a set of lead-times, or all three which agree'
+        return fdate, target, lead_low, lead_high
+    else:
+        assert (
+            False
+        ), "Must provide either a TARGET in three-letter format for one month, or a range of months, or a set of lead-times, or all three which agree"
 
 
 def subx_target(target=None, lead_low=None, lead_high=None):
-    leads = { 'week1': (1, 7), 'week2': (7, 14), 'week3': (14, 21), 'week4':(21, 28), 'week34': (14, 28), 'week12': (1, 14), 'week23': (7, 21)}
-    lr = {leads[r]: r for r in leads.keys() }  
-    if target is not None and lead_high is not None and lead_low is not None: # if all are supplied
-        assert target in leads.keys(), 'invalid subx target {}'.format(target)
-        assert lead_high == leads[target][1] and lead_low == leads[target][0], 'target incompatible with leads '
-    elif target is not None and lead_low is None and lead_high is None: 
-        assert target in leads.keys(), 'invalid subx target {}'.format(target)
+    leads = {
+        "week1": (1, 7),
+        "week2": (7, 14),
+        "week3": (14, 21),
+        "week4": (21, 28),
+        "week34": (14, 28),
+        "week12": (1, 14),
+        "week23": (7, 21),
+    }
+    lr = {leads[r]: r for r in leads.keys()}
+    if (
+        target is not None and lead_high is not None and lead_low is not None
+    ):  # if all are supplied
+        assert target in leads.keys(), "invalid subx target {}".format(target)
+        assert (
+            lead_high == leads[target][1] and lead_low == leads[target][0]
+        ), "target incompatible with leads "
+    elif target is not None and lead_low is None and lead_high is None:
+        assert target in leads.keys(), "invalid subx target {}".format(target)
         lead_low, lead_high = leads[target]
-    elif target is None and lead_low is not None and lead_high is None: 
-        assert False, 'must either provide a target, or both leads, or a set of all three which agree'
-    elif target is None and lead_low is None and lead_high is not None: 
-        assert False, 'must either provide a target, or both leads, or a set of all three which agree'
+    elif target is None and lead_low is not None and lead_high is None:
+        assert (
+            False
+        ), "must either provide a target, or both leads, or a set of all three which agree"
+    elif target is None and lead_low is None and lead_high is not None:
+        assert (
+            False
+        ), "must either provide a target, or both leads, or a set of all three which agree"
     else:
-        target  = lr[(lead_low, lead_high)] if (lead_low, lead_high) in lr.keys() else 'custom'
+        target = (
+            lr[(lead_low, lead_high)]
+            if (lead_low, lead_high) in lr.keys()
+            else "custom"
+        )
     return target, lead_low, lead_high
 
-    
+
 def first_hdate_in_training_season(fdate):
     start = dt.datetime(fdate.year, fdate.month, 1)
-    while start.weekday() != 4: 
+    while start.weekday() != 4:
         start = start + dt.Timedelta(days=1)
     return start
 
+
 def targetcenter(target):
     ts, te = parse_target(target)
-    if ts == te: 
-        return threeletters[ts] 
-    else: 
-        if te > ts: 
-            ndx = (te + ts ) // 2 
-            if ndx > 12: 
+    if ts == te:
+        return threeletters[ts]
+    else:
+        if te > ts:
+            ndx = (te + ts) // 2
+            if ndx > 12:
                 ndx -= 12
             return threeletters[ndx]
-        else: 
-            ndx = (te + 12 + ts ) // 2 
-            if ndx > 12: 
+        else:
+            ndx = (te + 12 + ts) // 2
+            if ndx > 12:
                 ndx -= 12
             return threeletters[ndx]

--- a/src/cptio/utilities/utilities.py
+++ b/src/cptio/utilities/utilities.py
@@ -1,13 +1,14 @@
-import datetime as dt 
+import datetime as dt
 from ..fileio import *
 import xarray as xr
 
 
 json_types = [dict, list, str, int, float, bool]
 
+
 def toJSON(obj):
-    ret = {} 
-    for key in vars(obj).keys(): 
+    ret = {}
+    for key in vars(obj).keys():
         if type(vars(obj)[key]) in json_types:
             if type(vars(obj)[key]) == dict:
                 dct = vars(obj)[key]
@@ -15,27 +16,17 @@ def toJSON(obj):
                     for key1 in dct.keys():
                         dct[key1] = toJSON(dct[key])
                 ret[key] = dct
-            else: 
+            else:
                 ret[key] = vars(obj)[key]
-        else: 
+        else:
             ret[key] = toJSON(vars(obj)[key])
     return ret
-    
+
 
 def recursive_getattr(obj, attr):
-    if '.' in attr:
-        attrs = attr.split('.')
-        next = '.'.join(attrs[1:])
+    if "." in attr:
+        attrs = attr.split(".")
+        next = ".".join(attrs[1:])
         return recursive_getattr(getattr(obj, attrs[0]), next)
     else:
         return getattr(obj, attr)
-
-
-
-
-
-
-
-
-
-

--- a/src/cptio/utilities/verify.py
+++ b/src/cptio/utilities/verify.py
@@ -37,32 +37,40 @@ def is_valid_cptv10(da, assertmissing=True, assert_units=True):
         assert (
             dim in da.coords
         ), "Each dim on a CPTv10 must have corresponding coordinates"
-        assert (
-            len(da.coords[dim].values) == da.shape[list(da.dims).index(dim)]
-        ), "Each dim on a CPTv10 must have exactly one coordinate per index along that dimension"
+        assert len(da.coords[dim].values) == da.shape[list(da.dims).index(dim)], (
+            "Each dim on a CPTv10 must have exactly one coordinate per index along that"
+            " dimension"
+        )
     if "T" in da.dims:
         for dim in ["Ti", "Tf", "S"]:
             if dim in da.coords:
                 assert (
                     len(da.coords[dim].values) == da.shape[list(da.dims).index("T")]
-                ), "If the CPTv10 has optional Time coordinates Ti, Tf, or S, they must be indexing the T dimension"
+                ), (
+                    "If the CPTv10 has optional Time coordinates Ti, Tf, or S, they"
+                    " must be indexing the T dimension"
+                )
     for dim in ["Ti", "Tf", "S"]:
         if dim in da.dims:
-            assert (
-                "T" in da.dims
-            ), "if the optional time coordinates are present on the CPTv10, the required time coord must also be"
+            assert "T" in da.dims, (
+                "if the optional time coordinates are present on the CPTv10, the"
+                " required time coord must also be"
+            )
     if "Ti" in da.coords:
-        assert (
-            "Tf" in da.coords
-        ), "Cannot have one optional time coordinate and not the other. found Ti but not Tf. except for S"
+        assert "Tf" in da.coords, (
+            "Cannot have one optional time coordinate and not the other. found Ti but"
+            " not Tf. except for S"
+        )
     if "Tf" in da.coords:
-        assert (
-            "Ti" in da.coords
-        ), "Cannot have one optional time coordinate and not the other. found Tf but not Ti. except for S"
+        assert "Ti" in da.coords, (
+            "Cannot have one optional time coordinate and not the other. found Tf but"
+            " not Ti. except for S"
+        )
     if assertmissing:
-        assert (
-            "missing" in da.attrs.keys()
-        ), "CPTv10 is required to have a 'missing' attribute indicating the 'missing_value' value which replaces NaNs in CPT"
+        assert "missing" in da.attrs.keys(), (
+            "CPTv10 is required to have a 'missing' attribute indicating the"
+            " 'missing_value' value which replaces NaNs in CPT"
+        )
         assert not np.isnan(
             float(da.attrs["missing"])
         ), "CPTv10 Missing Value cannot be NaN"

--- a/src/cptio/utilities/verify.py
+++ b/src/cptio/utilities/verify.py
@@ -1,48 +1,73 @@
-import xarray as xr 
-import numpy as np 
+import xarray as xr
+import numpy as np
+
 
 def check_dataarray(X, dims):
     """Checks that the specified dimensions are dimensions and coordinates on X"""
-    assert type(X) == xr.DataArray, 'X ({}) must be an Xarray DataArray '.format(type(X))
-    for dim in dims: 
-        assert dim in X.dims, 'Missing dimensions on X ({}): {}'.format(X.dims, dim)
-        
+    assert type(X) == xr.DataArray, "X ({}) must be an Xarray DataArray ".format(
+        type(X)
+    )
+    for dim in dims:
+        assert dim in X.dims, "Missing dimensions on X ({}): {}".format(X.dims, dim)
+
+
 def ax_to_2d(ax, T, M):
-    if T == 1 and M == 1: 
+    if T == 1 and M == 1:
         return [[ax]]
-    elif T == 1 and M > 1: 
-        return [ ax ]
-    elif T > 1 and M == 1: 
+    elif T == 1 and M > 1:
+        return [ax]
+    elif T > 1 and M == 1:
         return [[ax[i]] for i in range(len(ax))]
-    else: 
-        return ax 
+    else:
+        return ax
+
 
 def is_valid_cptv10(da, assertmissing=True, assert_units=True):
-    valid_dims = ['T', 'X', 'Y', 'Mode', 'index', 'C']
-    valid_coords = ['T', 'Ti', 'Tf', 'S', 'X', 'Y', 'Mode', 'index', 'C']
+    valid_dims = ["T", "X", "Y", "Mode", "index", "C"]
+    valid_coords = ["T", "Ti", "Tf", "S", "X", "Y", "Mode", "index", "C"]
     assert type(da) == xr.DataArray, "CPTv10 only deals with data arrays, not datasets"
-    assert len(list(da.dims)) >= 2 and len(list(da.dims)) <= 4, 'CPTv10 can only have between 2-4 dimensions'
+    assert (
+        len(list(da.dims)) >= 2 and len(list(da.dims)) <= 4
+    ), "CPTv10 can only have between 2-4 dimensions"
     for dim in da.dims:
-        assert dim in valid_dims, 'Invalid dim for a CPTv10: {}'.format(dim)
-    for coord in da.coords: 
-         assert coord in valid_coords, 'Invalid coord for a CPTv10: {}'.format(coord)
+        assert dim in valid_dims, "Invalid dim for a CPTv10: {}".format(dim)
+    for coord in da.coords:
+        assert coord in valid_coords, "Invalid coord for a CPTv10: {}".format(coord)
     for dim in da.dims:
-        assert dim in da.coords, 'Each dim on a CPTv10 must have corresponding coordinates'
-        assert len(da.coords[dim].values) == da.shape[list(da.dims).index(dim)], 'Each dim on a CPTv10 must have exactly one coordinate per index along that dimension'
-    if 'T' in da.dims: 
-        for dim in ['Ti', 'Tf', 'S']:
-            if dim in da.coords: 
-                assert len(da.coords[dim].values) == da.shape[list(da.dims).index('T')], 'If the CPTv10 has optional Time coordinates Ti, Tf, or S, they must be indexing the T dimension'
-    for dim in ['Ti', 'Tf', 'S']: 
-        if dim in da.dims: 
-            assert 'T' in da.dims, "if the optional time coordinates are present on the CPTv10, the required time coord must also be"
-    if 'Ti' in da.coords:
-        assert 'Tf' in da.coords, 'Cannot have one optional time coordinate and not the other. found Ti but not Tf. except for S'
-    if 'Tf' in da.coords:
-        assert 'Ti' in da.coords, 'Cannot have one optional time coordinate and not the other. found Tf but not Ti. except for S'
+        assert (
+            dim in da.coords
+        ), "Each dim on a CPTv10 must have corresponding coordinates"
+        assert (
+            len(da.coords[dim].values) == da.shape[list(da.dims).index(dim)]
+        ), "Each dim on a CPTv10 must have exactly one coordinate per index along that dimension"
+    if "T" in da.dims:
+        for dim in ["Ti", "Tf", "S"]:
+            if dim in da.coords:
+                assert (
+                    len(da.coords[dim].values) == da.shape[list(da.dims).index("T")]
+                ), "If the CPTv10 has optional Time coordinates Ti, Tf, or S, they must be indexing the T dimension"
+    for dim in ["Ti", "Tf", "S"]:
+        if dim in da.dims:
+            assert (
+                "T" in da.dims
+            ), "if the optional time coordinates are present on the CPTv10, the required time coord must also be"
+    if "Ti" in da.coords:
+        assert (
+            "Tf" in da.coords
+        ), "Cannot have one optional time coordinate and not the other. found Ti but not Tf. except for S"
+    if "Tf" in da.coords:
+        assert (
+            "Ti" in da.coords
+        ), "Cannot have one optional time coordinate and not the other. found Tf but not Ti. except for S"
     if assertmissing:
-        assert 'missing' in da.attrs.keys(), "CPTv10 is required to have a 'missing' attribute indicating the 'missing_value' value which replaces NaNs in CPT"
-        assert not np.isnan(float(da.attrs['missing'])), "CPTv10 Missing Value cannot be NaN"
-    
+        assert (
+            "missing" in da.attrs.keys()
+        ), "CPTv10 is required to have a 'missing' attribute indicating the 'missing_value' value which replaces NaNs in CPT"
+        assert not np.isnan(
+            float(da.attrs["missing"])
+        ), "CPTv10 Missing Value cannot be NaN"
+
     if assert_units:
-        assert 'units' in da.attrs.keys(), 'CPTv10 is required to have a "units" attribute'  
+        assert (
+            "units" in da.attrs.keys()
+        ), 'CPTv10 is required to have a "units" attribute'

--- a/tests/test_cptformat.py
+++ b/tests/test_cptformat.py
@@ -1,72 +1,109 @@
 from cptio import *
-from pathlib import Path 
-import pytest 
+from pathlib import Path
+import pytest
+
 
 def xarray_equals(x, y):
     return (x - y).sum() == 0
 
+
 @pytest.mark.fileio
 def test_gcm_input():
-    if Path('test.tsv').is_file():
-        Path('test.tsv').unlink()
-    x = open_cptdataset(Path( __file__ ).absolute().parents[0] / 'data/SEASONAL_CANCM4I_PRCP_HCST_JUN-SEP_None_2021-05.tsv').prec
-    testfile = to_cptv10(x, opfile='test.tsv')
+    if Path("test.tsv").is_file():
+        Path("test.tsv").unlink()
+    x = open_cptdataset(
+        Path(__file__).absolute().parents[0]
+        / "data/SEASONAL_CANCM4I_PRCP_HCST_JUN-SEP_None_2021-05.tsv"
+    ).prec
+    testfile = to_cptv10(x, opfile="test.tsv")
     assert xarray_equals(open_cptdataset(testfile), x)
-    
+
 
 @pytest.mark.fileio
 def test_cpc_input():
-    if Path('test.tsv').is_file():
-        Path('test.tsv').unlink()
-    y = open_cptdataset( Path( __file__).absolute().parents[0] / 'data/SEASONAL_CPCCMAPURD_PRCP_OBS_JUN-SEP_None_2021-05.tsv').prate
-    testfile = to_cptv10(y, opfile='test.tsv')
+    if Path("test.tsv").is_file():
+        Path("test.tsv").unlink()
+    y = open_cptdataset(
+        Path(__file__).absolute().parents[0]
+        / "data/SEASONAL_CPCCMAPURD_PRCP_OBS_JUN-SEP_None_2021-05.tsv"
+    ).prate
+    testfile = to_cptv10(y, opfile="test.tsv")
     assert xarray_equals(open_cptdataset(testfile), y)
+
 
 @pytest.mark.fileio
 def test_missing_data():
-    if Path('test.tsv').is_file():
-        Path('test.tsv').unlink()
-    x = open_cptdataset(Path( __file__ ).absolute().parents[0] / 'data/lesotho_ond.tsv').rfe
-    testfile = to_cptv10(x, opfile='test.tsv')
+    if Path("test.tsv").is_file():
+        Path("test.tsv").unlink()
+    x = open_cptdataset(
+        Path(__file__).absolute().parents[0] / "data/lesotho_ond.tsv"
+    ).rfe
+    testfile = to_cptv10(x, opfile="test.tsv")
     assert xarray_equals(open_cptdataset(testfile), x)
+
 
 @pytest.mark.fileio
 def test_probabilistic_data():
-    if Path('test.tsv').is_file():
-        Path('test.tsv').unlink()
-    x = open_cptdataset(Path( __file__ ).absolute().parents[0] / 'data/prob_rfcsts.tsv')
-    testfile = to_cptv10(getattr(x, [i for i in x.data_vars][0]), opfile='test.tsv')
+    if Path("test.tsv").is_file():
+        Path("test.tsv").unlink()
+    x = open_cptdataset(Path(__file__).absolute().parents[0] / "data/prob_rfcsts.tsv")
+    testfile = to_cptv10(getattr(x, [i for i in x.data_vars][0]), opfile="test.tsv")
     assert xarray_equals(open_cptdataset(testfile), x)
+
 
 @pytest.mark.fileio
 def test_skill():
-    if Path('test.tsv').is_file():
-        Path('test.tsv').unlink()
-    x = open_cptdataset(Path( __file__ ).absolute().parents[0] / 'data/pearson.txt')
-    testfile = to_cptv10(getattr(x, [i for i in x.data_vars][0]), opfile='test.tsv', assertmissing=False, assert_units=False)
+    if Path("test.tsv").is_file():
+        Path("test.tsv").unlink()
+    x = open_cptdataset(Path(__file__).absolute().parents[0] / "data/pearson.txt")
+    testfile = to_cptv10(
+        getattr(x, [i for i in x.data_vars][0]),
+        opfile="test.tsv",
+        assertmissing=False,
+        assert_units=False,
+    )
     assert xarray_equals(open_cptdataset(testfile), x)
+
 
 @pytest.mark.fileio
 def test_spatial_loadings():
-    if Path('test.tsv').is_file():
-        Path('test.tsv').unlink()
-    x = open_cptdataset(Path( __file__ ).absolute().parents[0] / 'data/predictand_cca_spatial_loadings.txt')
-    testfile = to_cptv10(getattr(x, [i for i in x.data_vars][0]), opfile='test.tsv', assertmissing=False, assert_units=False)
+    if Path("test.tsv").is_file():
+        Path("test.tsv").unlink()
+    x = open_cptdataset(
+        Path(__file__).absolute().parents[0]
+        / "data/predictand_cca_spatial_loadings.txt"
+    )
+    testfile = to_cptv10(
+        getattr(x, [i for i in x.data_vars][0]),
+        opfile="test.tsv",
+        assertmissing=False,
+        assert_units=False,
+    )
     assert xarray_equals(open_cptdataset(testfile), x)
 
+
 @pytest.mark.fileio
-def test_eof_timeseries(): 
-    if Path('test.tsv').is_file():
-        Path('test.tsv').unlink()
-    x = open_cptdataset(Path( __file__ ).absolute().parents[0] / 'data/predictand_eof_timeseries.txt')
-    testfile = to_cptv10(getattr(x, [i for i in x.data_vars][0]), opfile='test.tsv', assertmissing=False, assert_units=False)
+def test_eof_timeseries():
+    if Path("test.tsv").is_file():
+        Path("test.tsv").unlink()
+    x = open_cptdataset(
+        Path(__file__).absolute().parents[0] / "data/predictand_eof_timeseries.txt"
+    )
+    testfile = to_cptv10(
+        getattr(x, [i for i in x.data_vars][0]),
+        opfile="test.tsv",
+        assertmissing=False,
+        assert_units=False,
+    )
     assert xarray_equals(open_cptdataset(testfile), x)
+
 
 @pytest.mark.fileio
 def test_canonical_correlation():
-    if Path('test.tsv').is_file():
-        Path('test.tsv').unlink()
-    x = open_cptdataset(Path( __file__ ).absolute().parents[0] / 'data/cca_canonical_correlation.txt')
-    testfile = to_cptv10(getattr(x, [i for i in x.data_vars][0]), opfile='test.tsv')
+    if Path("test.tsv").is_file():
+        Path("test.tsv").unlink()
+    x = open_cptdataset(
+        Path(__file__).absolute().parents[0] / "data/cca_canonical_correlation.txt"
+    )
+    testfile = to_cptv10(getattr(x, [i for i in x.data_vars][0]), opfile="test.tsv")
     assert xarray_equals(open_cptdataset(testfile), x)
-


### PR DESCRIPTION
CPT allows dates to be expressed as either YYYY-MM or YYYY-MM-DD. In CPT seasonal target periods were intended to be expressed using YYYY-MM format, but pycpt currently uses YYYY-MM-DD for both seasonal and subseasonal. That works in most cases, but fails when the season ends in February, because in that case the season length in days is different in leap years than in non-leap years, which CPT rejects. Here we work around that by changing to YYYY-MM format for seasonal target periods.

This PR looks huge, but the substantive changes aren't that big. The first four commits do nothing but break up long lines to make the code more readable, and factor out some code that had been copy-pasted several times. Only the last two commits change the behavior. So I recommend reading one commit at a time, and concentrating on the last two.

With this change, the pycpt-operational-WAfrica notebook runs to completion. You may have to use `force_downloads = True` if you have files downloaded with the old version.